### PR TITLE
[HIGH] Allow decimals in R0 Calculator 

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -4,10 +4,20 @@
     <details>
       <summary>General</summary>
       <label for="days">Days:</label>
-      <input name="days" v-model.number="simulation.days" type="number" />
+      <input
+        name="days"
+        v-model.number="simulation.days"
+        type="number"
+        step="any"
+      />
 
       <label for="step">Step:</label>
-      <input name="step" v-model.number="simulation.step" type="number" />
+      <input
+        name="step"
+        v-model.number="simulation.step"
+        type="number"
+        step="any"
+      />
     </details>
     <details>
       <summary>Initial conditions</summary>

--- a/src/components/RoCalculator/Calculator.vue
+++ b/src/components/RoCalculator/Calculator.vue
@@ -95,14 +95,12 @@ import { preciseRound } from "../../utils";
 
 function initialTableData(groups, contagionRates) {
   // eslint-disable-next-line no-unused-vars
-  return new Array(groups)
-    .fill()
-    .map((_) => ({
-      n: 0,
-      contagionRates: new Array(contagionRates).fill(0),
-      totalContagion: 0,
-      product: 0,
-    }));
+  return new Array(groups).fill().map((_) => ({
+    n: 0,
+    contagionRates: new Array(contagionRates).fill(0),
+    totalContagion: 0,
+    product: 0,
+  }));
 }
 
 export default {

--- a/src/components/RoCalculator/Calculator.vue
+++ b/src/components/RoCalculator/Calculator.vue
@@ -138,7 +138,7 @@ export default {
   },
   methods: {
     handlePopulationChange(g_idx, ev) {
-      const value = ev.target.value && parseFloat(ev.target.value, 10);
+      const value = ev.target.value && parseFloat(ev.target.value);
       const group = this.tableData[g_idx];
 
       group.n = value;
@@ -147,7 +147,7 @@ export default {
       this.calculateRo();
     },
     handleContagionChange(g_idx, c_idx, ev) {
-      const value = ev.target.value && parseFloat(ev.target.value, 10);
+      const value = ev.target.value && parseFloat(ev.target.value);
       const group = this.tableData[g_idx];
 
       group.contagionRates[c_idx] = value;
@@ -249,17 +249,17 @@ export default {
 
 <style lang="sass" scoped>
 table
-    input
-        border: 1px solid black
+  input
+    border: 1px solid black
 
-        &.small
-            width: 2em
-        &.normal
-            width: 6em
+    &.small
+      width: 2em
+      &.normal
+        width: 6em
 
     th,
     td
-        text-align: center
+      text-align: center
 
 .section
   margin-bottom: 2em

--- a/src/components/RoCalculator/Calculator.vue
+++ b/src/components/RoCalculator/Calculator.vue
@@ -10,6 +10,7 @@
         <input
           name="p"
           type="number"
+          step="any"
           v-model.number="variables.p"
           @change="calculateRo"
         />
@@ -18,6 +19,7 @@
         <input
           name="gamma"
           type="number"
+          step="any"
           v-model.number="variables.gamma"
           @change="calculateRo"
         />
@@ -26,6 +28,7 @@
         <input
           name="s"
           type="number"
+          step="any"
           v-model.number="variables.s"
           @change="calculateRo"
         />
@@ -54,6 +57,7 @@
                 <input
                   class="normal"
                   type="number"
+                  step="any"
                   :value="group.n"
                   @change="(ev) => handlePopulationChange(idx, ev)"
                   v-on:paste="(ev) => handlePaste(idx, -1, ev)"
@@ -63,13 +67,14 @@
                 <input
                   class="small"
                   type="number"
+                  step="any"
                   :value="c"
                   @change="(ev) => handleContagionChange(idx, c_idx, ev)"
                   v-on:paste="(ev) => handlePaste(idx, c_idx, ev)"
                 />
               </td>
               <td>{{ group.totalContagion }}</td>
-              <td>{{ group.product }}</td>
+              <td>{{ group.product | toFixed(2) }}</td>
             </tr>
           </tbody>
         </table>
@@ -90,17 +95,19 @@ import { preciseRound } from "../../utils";
 
 function initialTableData(groups, contagionRates) {
   // eslint-disable-next-line no-unused-vars
-  return new Array(groups).fill().map((_) => ({
-    n: 0,
-    contagionRates: new Array(contagionRates).fill(0),
-    totalContagion: 0,
-    product: 0,
-  }));
+  return new Array(groups)
+    .fill()
+    .map((_) => ({
+      n: 0,
+      contagionRates: new Array(contagionRates).fill(0),
+      totalContagion: 0,
+      product: 0,
+    }));
 }
 
 export default {
   components: { Results },
-  data: function() {
+  data: function () {
     return {
       numberGroups: NUMBER_GROUPS,
       numberContagionRates: NUMBER_CONTAGION_RATES,
@@ -121,12 +128,17 @@ export default {
       },
     };
   },
-  created: function() {
+  created: function () {
     this.loadValues();
+  },
+  filters: {
+    toFixed(value, decimals) {
+      return value.toFixed(decimals);
+    },
   },
   methods: {
     handlePopulationChange(g_idx, ev) {
-      const value = ev.target.value && parseInt(ev.target.value, 10);
+      const value = ev.target.value && parseFloat(ev.target.value, 10);
       const group = this.tableData[g_idx];
 
       group.n = value;
@@ -135,7 +147,7 @@ export default {
       this.calculateRo();
     },
     handleContagionChange(g_idx, c_idx, ev) {
-      const value = ev.target.value && parseInt(ev.target.value, 10);
+      const value = ev.target.value && parseFloat(ev.target.value, 10);
       const group = this.tableData[g_idx];
 
       group.contagionRates[c_idx] = value;

--- a/src/components/RoCalculator/Calculator.vue
+++ b/src/components/RoCalculator/Calculator.vue
@@ -138,7 +138,7 @@ export default {
   },
   methods: {
     handlePopulationChange(g_idx, ev) {
-      const value = ev.target.value && parseFloat(ev.target.value);
+      const value = ev.target.value && Number(ev.target.value);
       const group = this.tableData[g_idx];
 
       group.n = value;
@@ -147,7 +147,7 @@ export default {
       this.calculateRo();
     },
     handleContagionChange(g_idx, c_idx, ev) {
-      const value = ev.target.value && parseFloat(ev.target.value);
+      const value = ev.target.value && Number(ev.target.value);
       const group = this.tableData[g_idx];
 
       group.contagionRates[c_idx] = value;
@@ -254,8 +254,8 @@ table
 
     &.small
       width: 2em
-      &.normal
-        width: 6em
+    &.normal
+      width: 6em
 
     th,
     td

--- a/src/components/editor/Condition.vue
+++ b/src/components/editor/Condition.vue
@@ -4,6 +4,7 @@
     <input
       v-model.number="simulation.initial_conditions[comp.name]"
       type="number"
+      step="any"
     />
   </div>
 </template>

--- a/src/components/editor/Param.vue
+++ b/src/components/editor/Param.vue
@@ -17,18 +17,21 @@
         v-model.number="simulation.iterate.start"
         :id="param + 'Start'"
         type="number"
+        step="any"
       />
       <label :for="param + 'End'">End:</label>
       <input
         v-model.number="simulation.iterate.end"
         :id="param + 'End'"
         type="number"
+        step="any"
       />
       <label :for="param + 'Intervals'">Intervals:</label>
       <input
         v-model.number="simulation.iterate.intervals"
         :id="param + 'Intervals'"
         type="number"
+        step="any"
       />
     </div>
     <div v-else>
@@ -36,6 +39,7 @@
       <input
         v-model.number="simulation.params[param.name]"
         type="number"
+        step="any"
         :id="param"
       />
     </div>


### PR DESCRIPTION
Change values to float and show multiplication with two decimals. 
Add to each number input attribute step any to allow decimals in firefox.
Issue: #63 